### PR TITLE
Update editDescription.html

### DIFF
--- a/client/templates/includes/editModules/editDescription/editDescription.html
+++ b/client/templates/includes/editModules/editDescription/editDescription.html
@@ -17,7 +17,7 @@
             </div>
         </form>
 
-        <button class="btn-floating top-right-btn dark-grey  waves-effect waves-light ">
+        <a href="#" class="btn-floating top-right-btn dark-grey  waves-effect waves-light ">
             {{#if isEditingFlags.description}}
                 <i class="material-icons green-text tooltipped"
                    data-position="bottom" data-delay="50" data-tooltip="enregister"
@@ -26,5 +26,5 @@
                 <i class="material-icons tooltipped "
                    data-position="bottom" data-delay="50" data-tooltip="éditer" editDescriptionBtn>mode_edit</i>
             {{/if}}
-        </button>
+        </a>
 </template>


### PR DESCRIPTION
L'édit de la description ne fonctionne apparemment pas sous Firefox. Une méthode consiste à remplacer la balise "button" par une balise "a". Testé sous Firefox, Chrome et Opera.